### PR TITLE
Remove double dot from devirtualized output filename

### DIFF
--- a/NoVmp/main.cpp
+++ b/NoVmp/main.cpp
@@ -372,7 +372,7 @@ int main( int argc, const char** argv )
 
 	// Write the recompiled image.
 	//
-	image_path.replace_extension( "devirt." + image_path.extension().string() );
+	image_path.replace_extension( "devirt" + image_path.extension().string() );
 	write_raw( 
 		desc->raw.data(), 
 		desc->raw.size(), 


### PR DESCRIPTION
Not sure if the double dot in filename was really intended.

![screen_novmp](https://user-images.githubusercontent.com/16323119/90502967-f86fda00-e14e-11ea-9cbd-b1512bf75f39.png)
