### PR TITLE
Fix build errors on Linux

### DIFF
--- a/NoVmp/CMakeLists.txt
+++ b/NoVmp/CMakeLists.txt
@@ -2,5 +2,9 @@ file(GLOB_RECURSE SOURCES CONFIGURE_DEPENDS *.cpp *.hpp)
 
 add_executable(${PROJECT_NAME} ${SOURCES})
 
+
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
 target_include_directories(${PROJECT_NAME} PRIVATE ../linux-pe)
-target_link_libraries(${PROJECT_NAME} PRIVATE VTIL)
+target_link_libraries(${PROJECT_NAME} PRIVATE VTIL Threads::Threads)

--- a/NoVmp/demo_compiler.hpp
+++ b/NoVmp/demo_compiler.hpp
@@ -240,7 +240,7 @@ namespace vtil
 				// Iterate every register.
 				//
 				mtx.lock_shared();
-				std::optional<register_desc> allocated_register = allocate_register( it, state, [ & ] ( const register_desc& reg )
+				std::optional<register_desc> allocated_register = allocate_register( it, state, [ &, it = it ] ( const register_desc& reg )
 				{
 					return optimizer::aux::is_alive( { it, reg }, blk->end(), xblock, nullptr );
 				} );
@@ -304,7 +304,7 @@ namespace vtil
 				{
 					// Make sure instruction does not reference this register.
 					// TODO: Handle
-					fassert( !symbolic::variable{ it, operand{ res }.reg() }.written_by( it ) );
+					fassert( ( !symbolic::variable{ it, operand{ res }.reg() }.written_by( it ) ) );
 
 					// Insert a VPINW.
 					//
@@ -324,7 +324,7 @@ namespace vtil
 
 					// Make sure instruction does not reference this register.
 					// TODO: Handle
-					fassert( !symbolic::variable{ it, operand{res}.reg() }.accessed_by( it ) );
+					fassert( ( !symbolic::variable{ it, operand{res}.reg() }.accessed_by( it ) ) );
 
 					// Allocate a temporary to hold the previous value of the register.
 					//
@@ -1168,7 +1168,7 @@ namespace vtil
 			{
 				// TODO: What to do if this triggers?
 				//
-				fassert( !symbolic::variable{ it, state->frame_register }.written_by( it ) );
+				fassert( ( !symbolic::variable{ it, state->frame_register }.written_by( it ) ) );
 
 				// If immmediate:
 				//

--- a/NoVmp/emulator/emulator.cpp
+++ b/NoVmp/emulator/emulator.cpp
@@ -29,6 +29,9 @@
 #include <vtil/io>
 #include "rwx_allocator.hpp"
 
+#ifndef _WIN32
+#define __stdcall __attribute__ ( ( ms_abi ) )
+#endif
 
 /*
 	mov     rax, rsp

--- a/NoVmp/emulator/rwx_allocator.cpp
+++ b/NoVmp/emulator/rwx_allocator.cpp
@@ -104,7 +104,7 @@ namespace mem
 #else
 		// Free the page(s) we've allocated.
 		//
-		mmunmap( desc, desc->allocation_size );
+		munmap( desc, desc->allocation_size );
 #endif
 	}
 };

--- a/NoVmp/main.cpp
+++ b/NoVmp/main.cpp
@@ -13,7 +13,11 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
+#ifdef _WIN32
 #include <intrin.h>
+#else
+#include <x86intrin.h>
+#endif
 #include <fstream>
 #include <tuple>
 #include <vector>
@@ -27,7 +31,9 @@
 #include "vmprotect/vm_state.hpp"
 #include "demo_compiler.hpp"
 
+#ifdef _MSC_VER
 #pragma comment(linker, "/STACK:34359738368")
+#endif
 
 using namespace vtil::logger;
 
@@ -357,7 +363,7 @@ int main( int argc, const char** argv )
 
 	win::section_header_t* scn = nt_hdrs->get_section( nt_hdrs->file_header.num_sections++ );
 	memset( scn, 0, sizeof( win::section_header_t ) );
-	strcpy_s( scn->name, ".novmp" );
+	strcpy( scn->name, ".novmp" );
 	scn->characteristics.cnt_code = 1;
 	scn->characteristics.mem_execute = 1;
 	scn->characteristics.mem_read = 1;

--- a/NoVmp/vmprotect/rkey.hpp
+++ b/NoVmp/vmprotect/rkey.hpp
@@ -108,7 +108,7 @@ namespace vmp
 
 		// Write the emulation information and return the block
 		//
-		out.decrypt = [ = ] ( void* src, rkey_t key ) -> std::pair<rkey_value, rkey_t>
+		out.decrypt = [ =, block_stream = block_stream ] ( void* src, rkey_t key ) -> std::pair<rkey_value, rkey_t>
 		{
 			rkey_value value;
 			value.u64 = 0;


### PR DESCRIPTION
* `strcpy_s` is not supported on glibc, so use `strcpy`
* "reference to local binding 'it' declared in enclosing function" are
corrected with `it = it` in the capture section, etc.
* Replace `intrin.h` with `x86intrin.h` on non-Windows platforms
* Ensure pthreads is linked on Linux

---

```
$ clang --version
clang version 10.0.1 
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
```