### PR TITLE
Fix parsing issue for -vms

### DIFF
--- a/NoVmp/main.cpp
+++ b/NoVmp/main.cpp
@@ -110,7 +110,7 @@ int main( int argc, const char** argv )
 		if ( !strcmp( argv[ i ], "-vms" ) )
 		{
 			while ( ++i < argc && argv[ i ][ 0 ] != '-' )
-				target_vms.emplace_back( strtoul( argv[ i ], nullptr, 16 ) );
+				target_vms.emplace_back( strtoull( argv[ i ], nullptr, 16 ) );
 		}
 		else if ( !strcmp( argv[ i ], "-sections" ) )
 		{


### PR DESCRIPTION
> Indeed, `strtoul` only parses 32 bits values which results in `Lifting virtual-machine at 00000000FFFFFFFF...` message when trying to parse a specific VM using `-vms`.
Switched to `strtoull` as it is done for `-base` argument.

Actually it makes sense since it's supposed to be an RVA (I went a bit fast reading the readme). The fix is not even valid as the value is stored in a uint32_t anyways.
Dropping.